### PR TITLE
fix bug: non-ascii file name not supported

### DIFF
--- a/tika/tika.py
+++ b/tika/tika.py
@@ -318,7 +318,7 @@ def parse1(option, urlOrPath, serverEndpoint=ServerEndpoint, verbose=Verbose, ti
     headers = headers or {}
 
     path, file_type = getRemoteFile(urlOrPath, TikaFilesPath)
-    headers.update({'Accept': responseMimeType, 'Content-Disposition': make_content_disposition_header(path)})
+    headers.update({'Accept': responseMimeType, 'Content-Disposition': make_content_disposition_header(path.encode('utf-8') if type(path) is unicode_string else path)})
 
     if option not in services:
         log.warning('config option must be one of meta, text, or all; using all.')


### PR DESCRIPTION
tika.parser.from_file reports UnicodeEncodeError when called with non-ascii file name.
this commits fixes it.